### PR TITLE
fix: double V in kot cli version url

### DIFF
--- a/pkg/kgrid/app/kots.go
+++ b/pkg/kgrid/app/kots.go
@@ -24,8 +24,7 @@ import (
 )
 
 const (
-	DefaultKOTSVersion = "1.27.0"
-	DefaultK6Version   = "0.29.0"
+	DefaultKOTSVersion = "v1.27.0"
 )
 
 type AppStatusResponse struct {
@@ -284,7 +283,7 @@ func downloadKOTSBinary(version string) (string, error) {
 		version = DefaultKOTSVersion
 	}
 
-	url := fmt.Sprintf("https://github.com/replicatedhq/kots/releases/download/v%s/kots_linux_amd64.tar.gz", version)
+	url := fmt.Sprintf("https://github.com/replicatedhq/kots/releases/download/%s/kots_linux_amd64.tar.gz", version)
 	resp, err := http.Get(url)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to http get kots from %s", url)


### PR DESCRIPTION
Fixes the following error in the kgrid runner:
```
cluster grid-ad2a1e795c5e0cf57773bd96f816d698 failed with error: failed to get kots v1.49.0 binary: failed to download from https://github.com/replicatedhq/kots/releases/download/vv1.49.0/kots_linux_amd64.tar.gz, unexpected status code 404
```