### PR TITLE
Delete cluster when test is done

### DIFF
--- a/cmd/kgrid/cli/delete.go
+++ b/cmd/kgrid/cli/delete.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/replicatedhq/kgrid/pkg/kgrid/grid"
 	"github.com/replicatedhq/kgrid/pkg/kgrid/grid/types"
+	"github.com/replicatedhq/kgrid/pkg/kgrid/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"sigs.k8s.io/yaml"
@@ -31,7 +32,8 @@ func DeleteCmd() *cobra.Command {
 				return err
 			}
 
-			if err := grid.Delete(v.GetString("config-file"), gridSpec); err != nil {
+			log := logger.NewLogger(gridSpec.Spec.Clusters[0].Logger)
+			if err := grid.Delete(v.GetString("config-file"), gridSpec, log); err != nil {
 				return err
 			}
 

--- a/cmd/kgrid/cli/root.go
+++ b/cmd/kgrid/cli/root.go
@@ -44,6 +44,7 @@ func RootCmd() *cobra.Command {
 	cmd.AddCommand(DescribeCmd())
 	cmd.AddCommand(DeployCmd())
 	cmd.AddCommand(DeleteCmd())
+	cmd.AddCommand(RunCmd())
 
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	return cmd

--- a/cmd/kgrid/cli/run.go
+++ b/cmd/kgrid/cli/run.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kgrid/pkg/kgrid/grid"
+	"github.com/replicatedhq/kgrid/pkg/kgrid/grid/types"
+	"github.com/replicatedhq/kgrid/pkg/kgrid/logger"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"sigs.k8s.io/yaml"
+)
+
+func RunCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "run",
+		Short:         "Create, deploy, and tear down a grid",
+		SilenceErrors: true,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlags(cmd.Flags())
+		},
+		RunE: func(cmd *cobra.Command, args []string) (testError error) {
+			v := viper.GetViper()
+
+			if v.GetString("app") == "" {
+				testError = errors.New("app is not specified")
+				return
+			}
+
+			data, err := ioutil.ReadFile(v.GetString("from-yaml"))
+			if err != nil {
+				testError = errors.Wrap(err, "failed to read from-yaml file")
+				return
+			}
+
+			gridSpec := types.Grid{}
+			if err := yaml.Unmarshal(data, &gridSpec); err != nil {
+				testError = errors.Wrapf(err, "failed to unmarshal %s", v.GetString("from-yaml"))
+				return
+			}
+
+			if len(gridSpec.Spec.Clusters) == 0 {
+				testError = errors.New("no clusters defined in spec")
+				return
+			}
+
+			if v.GetString("name") != "" {
+				gridSpec.Name = v.GetString("name")
+			}
+
+			data, err = ioutil.ReadFile(v.GetString("app"))
+			if err != nil {
+				testError = errors.Wrap(err, "failed to read app spec file")
+				return
+			}
+
+			application := &types.Application{}
+			if err := yaml.Unmarshal(data, &application); err != nil {
+				testError = errors.Wrap(err, "failed to unmarshal app spec")
+				return
+			}
+
+			log := logger.NewLogger(gridSpec.Spec.Clusters[0].Logger)
+			log.StartThread("Testing app %s", getAppDisplayName(*application))
+			defer func() {
+				resultMark := ":white_check_mark:"
+				if testError != nil {
+					resultMark = ":x:"
+				}
+				log.FinishThread("%s Testing app %s", resultMark, getAppDisplayName(*application))
+			}()
+
+			if err := grid.Create(v.GetString("config-file"), &gridSpec, log); err != nil {
+				testError = errors.Wrap(err, "failed to create cluster")
+				return
+			}
+
+			if err := deployApp(v.GetString("config-file"), gridSpec.Name, v.GetString("app"), log); err != nil {
+				testError = errors.Wrap(err, "failed to deploy app")
+				// clean up cluster
+			}
+
+			if err := grid.Delete(v.GetString("config-file"), &gridSpec, log); err != nil {
+				// TODO: maybe this shouldn't fail the test
+				testError = errors.Wrap(err, "failed to delete cluster")
+				return
+			}
+
+			return
+		},
+	}
+
+	cmd.Flags().StringP("name", "n", "", "Name of the grid, overriding the name in the yaml metadata.name field")
+	cmd.Flags().String("from-yaml", "", "Path to YAML manifest describing the grid to create")
+	cmd.Flags().String("like", "", "Name of an existing grid to clone, into a new grid")
+	cmd.Flags().String("app", "", "Path to YAML manifest describing the application to deploy after grid is created")
+
+	return cmd
+}

--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -210,7 +210,7 @@ func getTestPodSpec(testID string, gridCluster *kgridv1alpha1.Cluster, app *kgri
 					Name:            "grid",
 					Command:         []string{"kgrid"},
 					Args: []string{
-						"create",
+						"run",
 						"--from-yaml",
 						"/kgrid-specs/grid.yaml",
 						"--app",

--- a/pkg/kgrid/grid/delete.go
+++ b/pkg/kgrid/grid/delete.go
@@ -12,7 +12,7 @@ import (
 	"github.com/replicatedhq/kgrid/pkg/kgrid/logger"
 )
 
-func Delete(configFilePath string, g *types.Grid) error {
+func Delete(configFilePath string, g *types.Grid, log logger.Logger) error {
 	gridConfigs, err := List(configFilePath)
 	if err != nil {
 		return err
@@ -33,8 +33,6 @@ func Delete(configFilePath string, g *types.Grid) error {
 				wg.Add(1)
 				go func(config *types.ClusterConfig, cluster *types.ClusterSpec) {
 					defer wg.Done()
-
-					log := logger.NewLogger(cluster.Logger)
 
 					err := deleteCluster(config, cluster, log)
 					if err != nil {


### PR DESCRIPTION
- Adds a new CLI subcommand that will create cluster, deploy app, and delete cluster.  I think this project doesn't need separate Create,  Deploy, and, Delete subcommands, but I left them alone.
- Fixes `waitForNodes`, which fails on the initial iteration when there are 0 nodes.
- Fixes cluster name inconsistency.  When creating and deleting a cluster, mismatching cluster name was used.